### PR TITLE
Support multiple markdown files

### DIFF
--- a/MarkdownQAGenerator/ActionInputs.cs
+++ b/MarkdownQAGenerator/ActionInputs.cs
@@ -21,5 +21,12 @@ namespace MarkdownQAGenerator
             Required = false,
             HelpText = "The name of the generated CrowdAnki deck.")]
         public string DeckName { get; set; } = null!;
+
+        [Option('r', "root-directory",
+            Default = null,
+            Required = false,
+            HelpText = "The root directory at which to start searching for the markdown files. " +
+                       "(Defaults to attempt to get the root from 'markdown-file')")]
+        public string RootDirectory { get; set; } = null!;
     }
 }

--- a/MarkdownQAGenerator/ActionInputs.cs
+++ b/MarkdownQAGenerator/ActionInputs.cs
@@ -24,9 +24,8 @@ namespace MarkdownQAGenerator
 
         [Option('r', "root-directory",
             Default = null,
-            Required = false,
-            HelpText = "The root directory at which to start searching for the markdown files. " +
-                       "(Defaults to attempt to get the root from 'markdown-file')")]
+            Required = true,
+            HelpText = "The root directory at which to start searching for the markdown files.")]
         public string RootDirectory { get; set; } = null!;
     }
 }

--- a/MarkdownQAGenerator/CrowdAnkiJsonGenerator.cs
+++ b/MarkdownQAGenerator/CrowdAnkiJsonGenerator.cs
@@ -33,8 +33,9 @@ namespace MarkdownQAGenerator
             matcher.AddInclude(markdownRegex);
             logger.LogInformation($"Root directory before setting the default: {rootDirectory}");
 
-            if (rootDirectory is null) rootDirectory = Path.GetDirectoryName(Path.GetFullPath(markdownRegex));
+            if (rootDirectory is null) rootDirectory = Path.GetFullPath(Path.GetDirectoryName(markdownRegex));
 
+            logger.LogInformation($"Test get directory not of full path {Path.GetDirectoryName(markdownRegex)}");
             logger.LogInformation($"Full path of markdown regex is {Path.GetFullPath(markdownRegex)}");
             logger.LogInformation($"Search for markdown files at '{markdownRegex}' in directory '{rootDirectory}'");
             IEnumerable<string?> files = matcher.GetResultsInFullPath(rootDirectory);

--- a/MarkdownQAGenerator/CrowdAnkiJsonGenerator.cs
+++ b/MarkdownQAGenerator/CrowdAnkiJsonGenerator.cs
@@ -33,7 +33,7 @@ namespace MarkdownQAGenerator
             matcher.AddInclude(markdownRegex);
             logger.LogInformation($"Root directory before setting the default: {rootDirectory}");
 
-            if (rootDirectory is null) rootDirectory = Path.GetFullPath(Path.GetDirectoryName(markdownRegex));
+            if (string.IsNullOrEmpty(rootDirectory)) rootDirectory = Path.GetFullPath(Path.GetDirectoryName(markdownRegex));
 
             logger.LogInformation($"Test get directory not of full path {Path.GetDirectoryName(markdownRegex)}");
             logger.LogInformation($"Full path of markdown regex is {Path.GetFullPath(markdownRegex)}");

--- a/MarkdownQAGenerator/CrowdAnkiJsonGenerator.cs
+++ b/MarkdownQAGenerator/CrowdAnkiJsonGenerator.cs
@@ -33,9 +33,10 @@ namespace MarkdownQAGenerator
             matcher.AddInclude(markdownRegex);
             logger.LogInformation($"Root directory before setting the default: {rootDirectory}");
 
-            if (string.IsNullOrEmpty(rootDirectory)) rootDirectory = Path.GetPathRoot(Path.GetFullPath(Path.GetDirectoryName(markdownRegex)));
+            if (string.IsNullOrEmpty(rootDirectory)) rootDirectory = Path.GetPathRoot(markdownRegex);
             logger.LogInformation($"Test current {Path.GetDirectoryName(markdownRegex)}");
 
+            logger.LogInformation($"Test got root directory of path directly {Path.GetPathRoot(markdownRegex)}");
             logger.LogInformation($"Test get full path of directory not of full path {Path.GetFullPath(Path.GetDirectoryName(markdownRegex))}");
             logger.LogInformation($"Test get root of full path of directory not of full path {Path.GetPathRoot(Path.GetFullPath(Path.GetDirectoryName(markdownRegex)))}");
             logger.LogInformation($"Full path of markdown regex is {Path.GetFullPath(markdownRegex)}");

--- a/MarkdownQAGenerator/CrowdAnkiJsonGenerator.cs
+++ b/MarkdownQAGenerator/CrowdAnkiJsonGenerator.cs
@@ -32,6 +32,8 @@ namespace MarkdownQAGenerator
             Matcher matcher = new();
             matcher.AddInclude(markdownRegex);
             if (rootDirectory is null) rootDirectory = Path.GetDirectoryName(Path.GetFullPath(markdownRegex));
+
+            logger.LogInformation($"Search for markdown files at '{markdownRegex}' in directory '{rootDirectory}'");
             IEnumerable<string?> files = matcher.GetResultsInFullPath(rootDirectory);
 
             foreach (var file in files)

--- a/MarkdownQAGenerator/CrowdAnkiJsonGenerator.cs
+++ b/MarkdownQAGenerator/CrowdAnkiJsonGenerator.cs
@@ -31,8 +31,11 @@ namespace MarkdownQAGenerator
 
             Matcher matcher = new();
             matcher.AddInclude(markdownRegex);
+            logger.LogInformation($"Root directory before setting the default: {rootDirectory}");
+
             if (rootDirectory is null) rootDirectory = Path.GetDirectoryName(Path.GetFullPath(markdownRegex));
 
+            logger.LogInformation($"Full path of markdown regex is {Path.GetFullPath(markdownRegex)}");
             logger.LogInformation($"Search for markdown files at '{markdownRegex}' in directory '{rootDirectory}'");
             IEnumerable<string?> files = matcher.GetResultsInFullPath(rootDirectory);
 

--- a/MarkdownQAGenerator/CrowdAnkiJsonGenerator.cs
+++ b/MarkdownQAGenerator/CrowdAnkiJsonGenerator.cs
@@ -34,9 +34,10 @@ namespace MarkdownQAGenerator
             logger.LogInformation($"Root directory before setting the default: {rootDirectory}");
 
             if (string.IsNullOrEmpty(rootDirectory)) rootDirectory = Path.GetPathRoot(Path.GetFullPath(Path.GetDirectoryName(markdownRegex)));
+            logger.LogInformation($"Test current {Path.GetDirectoryName(markdownRegex)}");
 
-            logger.LogInformation($"Test get directory not of full path {Path.GetDirectoryName(markdownRegex)}");
             logger.LogInformation($"Test get full path of directory not of full path {Path.GetFullPath(Path.GetDirectoryName(markdownRegex))}");
+            logger.LogInformation($"Test get root of full path of directory not of full path {Path.GetPathRoot(Path.GetFullPath(Path.GetDirectoryName(markdownRegex)))}");
             logger.LogInformation($"Full path of markdown regex is {Path.GetFullPath(markdownRegex)}");
             logger.LogInformation($"Search for markdown files at '{markdownRegex}' in directory '{rootDirectory}'");
             IEnumerable<string?> files = matcher.GetResultsInFullPath(rootDirectory);

--- a/MarkdownQAGenerator/CrowdAnkiJsonGenerator.cs
+++ b/MarkdownQAGenerator/CrowdAnkiJsonGenerator.cs
@@ -24,22 +24,15 @@ namespace MarkdownQAGenerator
         /// files. If not set, attempts to get the root Directory from the markdownRegex string.</param>
         /// <returns>A string with infos that can be passed on to the user (line breaks in '%0A')</returns>
         public static string GenerateAnkiJson(string markdownRegex, string destinationDirectory, string deckName,
-            ILogger? logger, string? rootDirectory)
+            ILogger? logger, string rootDirectory)
         {
             //generate AnkiJsonRepresentation
             RootDeck rootDeck = new(deckName);
 
             Matcher matcher = new();
             matcher.AddInclude(markdownRegex);
-            logger.LogInformation($"Root directory before setting the default: {rootDirectory}");
-
+            
             if (string.IsNullOrEmpty(rootDirectory)) rootDirectory = Path.GetPathRoot(markdownRegex);
-            logger.LogInformation($"Test current {Path.GetDirectoryName(markdownRegex)}");
-
-            logger.LogInformation($"Test got root directory of path directly {Path.GetPathRoot(markdownRegex)}");
-            logger.LogInformation($"Test get full path of directory not of full path {Path.GetFullPath(Path.GetDirectoryName(markdownRegex))}");
-            logger.LogInformation($"Test get root of full path of directory not of full path {Path.GetPathRoot(Path.GetFullPath(Path.GetDirectoryName(markdownRegex)))}");
-            logger.LogInformation($"Full path of markdown regex is {Path.GetFullPath(markdownRegex)}");
             logger.LogInformation($"Search for markdown files at '{markdownRegex}' in directory '{rootDirectory}'");
             IEnumerable<string?> files = matcher.GetResultsInFullPath(rootDirectory);
 

--- a/MarkdownQAGenerator/CrowdAnkiJsonGenerator.cs
+++ b/MarkdownQAGenerator/CrowdAnkiJsonGenerator.cs
@@ -33,9 +33,10 @@ namespace MarkdownQAGenerator
             matcher.AddInclude(markdownRegex);
             logger.LogInformation($"Root directory before setting the default: {rootDirectory}");
 
-            if (string.IsNullOrEmpty(rootDirectory)) rootDirectory = Path.GetFullPath(Path.GetDirectoryName(markdownRegex));
+            if (string.IsNullOrEmpty(rootDirectory)) rootDirectory = Path.GetPathRoot(Path.GetFullPath(Path.GetDirectoryName(markdownRegex)));
 
             logger.LogInformation($"Test get directory not of full path {Path.GetDirectoryName(markdownRegex)}");
+            logger.LogInformation($"Test get full path of directory not of full path {Path.GetFullPath(Path.GetDirectoryName(markdownRegex))}");
             logger.LogInformation($"Full path of markdown regex is {Path.GetFullPath(markdownRegex)}");
             logger.LogInformation($"Search for markdown files at '{markdownRegex}' in directory '{rootDirectory}'");
             IEnumerable<string?> files = matcher.GetResultsInFullPath(rootDirectory);

--- a/MarkdownQAGenerator/Program.cs
+++ b/MarkdownQAGenerator/Program.cs
@@ -36,7 +36,7 @@ static async Task StartAnkiGenerator(ActionInputs inputs, IHost host)
     if (destinationDirectory.EndsWith(Path.DirectorySeparatorChar))
         destinationDirectory = destinationDirectory.Substring(0, destinationDirectory.Length - 1);
     string infos =
-        AnkiJsonGenerator.GenerateAnkiJson(inputs.MarkDownFile, destinationDirectory, inputs.DeckName, logger);
+        AnkiJsonGenerator.GenerateAnkiJson(inputs.MarkDownFile, destinationDirectory, inputs.DeckName, logger, inputs.RootDirectory);
 
     // https://docs.github.com/actions/reference/workflow-commands-for-github-actions#setting-an-output-parameter
     Console.WriteLine($"::set-output name=conversion-stats::{infos}");

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # MarkdownQAGenerator
 
-A GitHub action to generate question-answer style cards from a markdown file and converts them to CrowdAnki files, so they can be used with the anki app. (Other formats may be supported in the future as well.)
+A GitHub action to generate question-answer style cards from markdown files and converts them to CrowdAnki files, so they can be used with the anki app. (Other formats may be supported in the future as well.)
 
-This action will parse a given Markdown file with a specific layout that is interpreted as questions and answers separated into chapters. See [Markdown file format](#markdown-file-format) for the details on how to create those elements. Based upon this html question answer cards sorted into chapters are created that are then converted to a .json file and media files, so that they can be imported to [Anki](https://apps.ankiweb.net/) via the [CrowdAnki](https://ankiweb.net/shared/info/1788670778) Plugin.
+This action will parse the given Markdown files with a specific layout that is interpreted as questions and answers separated into chapters. See [Markdown file format](#markdown-file-format) for the details on how to create those elements. Based upon this html question answer cards sorted into chapters are created that are then converted to a .json file and media files, so that they can be imported to [Anki](https://apps.ankiweb.net/) via the [CrowdAnki](https://ankiweb.net/shared/info/1788670778) Plugin.
 
 If you want to contribute or just run the actions console application locally please take a look at the notes [here](#how-to-contribute).
 
@@ -17,21 +17,23 @@ If you want to contribute or just run the actions console application locally pl
 ```yml
 - name: Generate Anki Questions from Markdown file
   id: question-generator
-  uses: HannesZeihsel/MarkdownQAGenerator@v1
+  uses: HannesZeihsel/MarkdownQAGenerator@V1.1
   with:
     markdown-file: './questions/TestMarkdown.md'
     destination-directory: './questions/Generated/'
+    root-directory: ${{ './' }}
     deck-name: 'MarkdownQAGenerator Question Deck'
 ```
 
-You can also pin to a [specific release](https://github.com/peter-evans/create-pull-request/releases) version in the format `@v3.x.x`
+You can also pin to a [specific release](https://github.com/peter-evans/create-pull-request/releases) version in the format `@V3.x.x`
 
 ### Action inputs
 
 | Name | Description | Required/Default |
 | --- | --- | --- |
-| `file` | The markdown file to be parsed and converted. (Can be a relative path) | Required |
+| `file` | The markdown files to be parsed and converted. In regex format relative to `root-directory` | Required |
 | `destination-directory` | The directory in which the generated data is saved to | Required |
+| `root-directory` | The root directory at which to start to search for the markdown files. | Default `New Deck` |
 | `deck-name` | The name that the root deck (containing all the chapters) should have | Default `New Deck` |
 
 ### Action outputs
@@ -52,7 +54,7 @@ on:
   push:
     branches: [ master ]
     paths:
-    - 'questions/TestMarkdown.md'  #Run only if the Markdown file was changed
+    - 'questions/*.md'  #Run only if the Markdown file was changed
   workflow_dispatch:
 
 jobs:
@@ -66,8 +68,9 @@ jobs:
       id: question-generator
       uses: HannesZeihsel/MarkdownQAGenerator@v1
       with:
-        markdown-file: './questions/TestMarkdown.md'
-        destination-directory: './questions/Generated/'
+         markdown-file: './questions/*.md'
+        destination-directory: ${{ './questions/Generated/' }}
+        root-directory: ${{ './' }}
         deck-name: 'MarkdownQAGenerator Question Deck'
       
     # Create a new Pull request

--- a/action.yml
+++ b/action.yml
@@ -18,6 +18,10 @@ inputs:
       'The name of the generated CrowdAnki deck.'
     required: false
     default: 'New Deck'
+  root-directory:
+    description:
+      'The root directory at which to start searching for the markdown files. (Defaults to attempt to get the root from markdown-file)'
+    required: false
 outputs:
   conversion-stats:
     description:
@@ -32,3 +36,5 @@ runs:
   - ${{ inputs.destination-directory }}
   - '-n'
   - ${{ inputs.deck-name }}
+  - '-r'
+  - ${{inputs.root-directory}}

--- a/action.yml
+++ b/action.yml
@@ -20,8 +20,8 @@ inputs:
     default: 'New Deck'
   root-directory:
     description:
-      'The root directory at which to start searching for the markdown files. (Defaults to attempt to get the root from markdown-file)'
-    required: false
+      'The root directory at which to start searching for the markdown files.'
+    required: true
 outputs:
   conversion-stats:
     description:


### PR DESCRIPTION
- now multiple markdown files can be used to generate an AnkiDeck
- the parameter `markdown-file` can now be used as a regex expression
- the required parameter `root-directory` was added as the base directory for the regex search